### PR TITLE
getKeys does not contain lists anymore

### DIFF
--- a/src/apps/provider/actions/keys.js
+++ b/src/apps/provider/actions/keys.js
@@ -9,14 +9,6 @@ export async function keys(state, keyStore, settings) {
     markAsLoading(state, keyStore);
     try {
         const keys = await backend.appointments.getKeys();
-
-        for (const providerKeys of keys.lists.providers) {
-            providerKeys.json = JSON.parse(providerKeys.data);
-        }
-        for (const mediatorKeys of keys.lists.mediators) {
-            mediatorKeys.json = JSON.parse(mediatorKeys.data);
-        }
-
         return {
             status: 'loaded',
             data: keys,


### PR DESCRIPTION
We decided to remove lists from the geyKeys endpoint. This has mainly performance reasons.

Two notes:
1. This depends on a merge request in services, which should be merged beforehand. (https://github.com/kiebitz-oss/services/pull/15)

~~2. I removed some validation function in the providers app, which @adewes also modified within another pull request. We should merge the PR from @adewes first, rebase this PR to the new master and apply his changes.~~